### PR TITLE
Fix bugs related to UndoCommand and RedoCommand

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -60,8 +60,8 @@ public class ModelManager implements Model {
     @Override
     public void undo() throws CommandException {
         if (!undoList.isEmpty()) {
-            redoList.add(addressBook);
-            addressBook = undoList.remove(undoList.size() - 1);
+            redoList.add(new AddressBook(addressBook));
+            addressBook.resetData(undoList.remove(undoList.size() - 1));
         } else {
             throw new CommandException(UndoCommand.MESSAGE_EMPTY);
         }
@@ -69,8 +69,8 @@ public class ModelManager implements Model {
     @Override
     public void redo() throws CommandException {
         if (!redoList.isEmpty()) {
-            undoList.add(addressBook);
-            addressBook = redoList.remove(redoList.size() - 1);
+            undoList.add(new AddressBook(addressBook));
+            addressBook.resetData(redoList.remove(redoList.size() - 1));
         } else {
             throw new CommandException(RedoCommand.MESSAGE_EMPTY);
         }

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
@@ -93,5 +94,45 @@ public class RedoCommandTest {
         assertCommandSuccess(redoCommand, model, expectedMessage, expectedModelThree);
         assertCommandSuccess(redoCommand, model, expectedMessage, expectedModelTwo);
         assertCommandSuccess(redoCommand, model, expectedMessage, expectedModelOne);
+    }
+
+    @Test
+    public void execute_exceedFiveRedos_failure() throws CommandException {
+        RedoCommand redoCommand = new RedoCommand();
+        String expectedMessage = RedoCommand.MESSAGE_SUCCESS;
+
+        /* add and delete patients */
+        Patient patientToAdd = new PatientBuilder().build();
+        model.addPerson(patientToAdd);
+        Model expectedModelOne = model;
+        Patient patientToDelete = model.getFilteredPatientList().get(INDEX_FIRST_PERSON.getZeroBased());
+        model.deletePerson(patientToDelete);
+        Model expectedModelTwo = model;
+        Patient secondPatientToDelete = model.getFilteredPatientList().get(INDEX_SECOND_PERSON.getZeroBased());
+        model.deletePerson(secondPatientToDelete);
+        Model expectedModelThree = model;
+
+        /* add and delete doctors */
+        Doctor doctorToAdd = new DoctorBuilder().build();
+        model.addPerson(doctorToAdd);
+        Model expectedModelFour = model;
+        Doctor doctorToDelete = model.getFilteredDoctorList().get(INDEX_FIRST_PERSON.getZeroBased());
+        model.deletePerson(doctorToDelete);
+        Model expectedModelFive = model;
+        Doctor secondDoctorToDelete = model.getFilteredDoctorList().get(INDEX_SECOND_PERSON.getZeroBased());
+        model.deletePerson(secondDoctorToDelete);
+
+        /* undo 5 times */
+        for (int i = 0; i < 5; i++) {
+            model.undo();
+        }
+
+        /* redo 6 times */
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModelFive);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModelFour);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModelThree);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModelTwo);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModelOne);
+        assertCommandFailure(redoCommand, model, RedoCommand.MESSAGE_EMPTY);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -4,10 +4,10 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.AddressBookBuilder.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -20,7 +20,7 @@ import seedu.address.testutil.PatientBuilder;
 public class UndoCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     @Test
-    public void execute_undoAdd_success() throws CommandException {
+    public void execute_undoAdd_success() {
         Patient validPatient = new PatientBuilder().build();
         UndoCommand undoCommand = new UndoCommand();
         String expectedMessage = UndoCommand.MESSAGE_SUCCESS;
@@ -78,5 +78,40 @@ public class UndoCommandTest {
         assertCommandSuccess(undoCommand, model, expectedMessage, expectedModelThree);
         assertCommandSuccess(undoCommand, model, expectedMessage, expectedModelTwo);
         assertCommandSuccess(undoCommand, model, expectedMessage, expectedModelOne);
+    }
+
+    @Test
+    public void execute_exceedFiveUndos_failure() {
+        UndoCommand undoCommand = new UndoCommand();
+        String expectedMessage = UndoCommand.MESSAGE_SUCCESS;
+
+        /* add and delete patients */
+        Patient patientToAdd = new PatientBuilder().build();
+        model.addPerson(patientToAdd);
+        Model expectedModelOne = model;
+        Patient patientToDelete = model.getFilteredPatientList().get(INDEX_FIRST_PERSON.getZeroBased());
+        model.deletePerson(patientToDelete);
+        Model expectedModelTwo = model;
+        Patient secondPatientToDelete = model.getFilteredPatientList().get(INDEX_SECOND_PERSON.getZeroBased());
+        model.deletePerson(secondPatientToDelete);
+        Model expectedModelThree = model;
+
+        /* add and delete doctors */
+        Doctor doctorToAdd = new DoctorBuilder().build();
+        model.addPerson(doctorToAdd);
+        Model expectedModelFour = model;
+        Doctor doctorToDelete = model.getFilteredDoctorList().get(INDEX_FIRST_PERSON.getZeroBased());
+        model.deletePerson(doctorToDelete);
+        Model expectedModelFive = model;
+        Doctor secondDoctorToDelete = model.getFilteredDoctorList().get(INDEX_SECOND_PERSON.getZeroBased());
+        model.deletePerson(secondDoctorToDelete);
+
+        /* undo 6 times */
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModelFive);
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModelFour);
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModelThree);
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModelTwo);
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModelOne);
+        assertCommandFailure(undoCommand, model, UndoCommand.MESSAGE_EMPTY);
     }
 }


### PR DESCRIPTION
UndoCommand and RedoCommand did not update the UI correct as intended as setAddressBook was not utilised. Instead, addressBook was assigned to the previous addressBook normally which led to the UI not receiving the feedback and updating accordingly.

RedoCommand did not work as well due to it referencing the same addressBook instance instead of creating a new one each time, thus redo simply lead to an empty addressBook being set each time.

Made the fixes necessary to correct the bugs. Also updated test cases to test for situations where the redo and undo commands are called over the maximum of 5 times, which should return the error message.