### PR TITLE
Add special tags for doctors and patients

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -122,12 +122,22 @@ public class EditCommand extends Command {
     private Person getEditedPerson(Model model, Person personToEdit) throws CommandException {
         Person editedPerson;
         if (personToEdit instanceof Patient) {
+            if (editPersonDescriptor.getTags().isPresent()
+                    && !editPersonDescriptor.isValidPatientTagList(editPersonDescriptor.getTags().get())) {
+                logger.warning("Invalid tag for patient");
+                throw new CommandException("Please enter a valid patient tag.");
+            }
             editedPerson = createEditedPatient((Patient) personToEdit, editPersonDescriptor);
         } else {
             assert personToEdit.isDoctor();
             if (editPersonDescriptor.getCondition().isPresent() || editPersonDescriptor.getBloodType().isPresent()) {
                 logger.warning("Error thrown - tried to edit condition / bloodtype of doctor");
                 throw new CommandException("Doctors cannot have Condition or BloodType fields.");
+            }
+            if (editPersonDescriptor.getTags().isPresent()
+                    && !editPersonDescriptor.isValidDoctorTagList(editPersonDescriptor.getTags().get())) {
+                logger.warning(editPersonDescriptor.getTags().toString());
+                throw new CommandException("Please enter valid Doctor tags.");
             }
             editedPerson = createEditedDoctor((Doctor) personToEdit, editPersonDescriptor);
         }
@@ -340,6 +350,38 @@ public class EditCommand extends Command {
             return Optional.ofNullable(bloodType);
         }
 
+        /**
+         * Ensures the set of tags contains only valid patient tags.
+         *
+         * @param tagSet The set of tags to be validated.
+         * @return true if the tag set is valid (contains zero or one valid patient tag), false otherwise.
+         */
+        public boolean isValidPatientTagList(Set<Tag> tagSet) {
+            if (tagSet.size() > 1) {
+                return false;
+            }
+            for (Tag tag : tagSet) {
+                if (!tag.isValidPatientTag()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Ensures the set of tags contains only valid doctor tags.
+         *
+         * @param tagSet The set of tags to be validated.
+         * @return true if the tag set is valid (contains no duplicate doctor tags), false otherwise.
+         */
+        public boolean isValidDoctorTagList(Set<Tag> tagSet) {
+            for (Tag tag : tagSet) {
+                if (!tag.isValidDoctorTag()) {
+                    return false;
+                }
+            }
+            return true;
+        }
 
         /**
          * Sets {@code tags} to this object's {@code tags}.

--- a/src/main/java/seedu/address/logic/parser/AddDoctorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddDoctorCommandParser.java
@@ -62,7 +62,7 @@ public class AddDoctorCommandParser implements Parser<AddDoctorCommand> {
         Remark remark = new Remark(""); // add command does not allow adding remarks straight away
         Gender gender = ParserUtil.parseGender(argMultimap.getValue(PREFIX_GENDER).get());
         Ic ic = ParserUtil.parseIc(argMultimap.getValue(PREFIX_NRIC).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Set<Tag> tagList = ParserUtil.parseDoctorTags(argMultimap.getAllValues(PREFIX_TAG));
         // appointments need to be added separately, so we initialise doctors with empty appointments
         Set<Appointment> appointmentList = new HashSet<>();
 

--- a/src/main/java/seedu/address/logic/parser/AddPatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPatientCommandParser.java
@@ -58,7 +58,7 @@ public class AddPatientCommandParser implements Parser<AddPatientCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPatientCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG,
                 PREFIX_GENDER, PREFIX_NRIC, PREFIX_CONDITION, PREFIX_BLOODTYPE, PREFIX_EMERGENCY_CONTACT);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
@@ -71,7 +71,7 @@ public class AddPatientCommandParser implements Parser<AddPatientCommand> {
         Ic ic = ParserUtil.parseIc(argMultimap.getValue(PREFIX_NRIC).get());
         BloodType bloodType = ParserUtil.parseBloodType(argMultimap.getValue(PREFIX_BLOODTYPE).get());
         Condition condition = ParserUtil.parseCondition(argMultimap.getValue(PREFIX_CONDITION).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Set<Tag> tagList = ParserUtil.parsePatientTags(argMultimap.getAllValues(PREFIX_TAG));
         // appointments need to be added separately, so we initialise patients with empty appointments
         Set<Appointment> appointmentList = new HashSet<>();
         Patient patient =

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -135,28 +135,125 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String tag} into a {@code Tag}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses a string to create a {@code Tag} object after processing the input string.
+     * The input string is trimmed and converted to uppercase. If the tag name is a valid
+     * patient tag name, it is prefixed with "priority: " before being used to create the tag.
      *
-     * @throws ParseException if the given {@code tag} is invalid.
+     * @param tag The string to be parsed into a Tag object.
+     * @return A Tag object representing the input string.
+     * @throws NullPointerException if the tag parameter is null.
      */
-    public static Tag parseTag(String tag) throws ParseException {
+    public static Tag parseTag(String tag) {
         requireNonNull(tag);
-        String trimmedTag = tag.trim();
-        if (!Tag.isValidTagName(trimmedTag)) {
-            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+        String trimmedTag = tag.trim().toUpperCase();
+        if (Tag.isValidPatientTagName(trimmedTag)) {
+            trimmedTag = "priority: " + trimmedTag;
         }
         return new Tag(trimmedTag);
     }
 
     /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
+     * Parses a collection of strings to create a set of {@code Tag} objects.
+     * Each string in the collection is processed to create a Tag. If a duplicate tag is found,
+     * a ParseException is thrown.
+     *
+     * @param tags The collection of strings to be parsed into Tag objects.
+     * @return A set of Tag objects.
+     * @throws ParseException if a duplicate tag is detected.
+     * @throws NullPointerException if the tags parameter is null.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
-            tagSet.add(parseTag(tagName));
+            Tag toAdd = parseTag(tagName);
+            if (tagSet.contains(toAdd)) {
+                throw new ParseException(Tag.DUPLICATE_TAG);
+            }
+            tagSet.add(toAdd);
+        }
+        return tagSet;
+    }
+
+    /**
+     * Parses a string to create a {@code Tag} object representing a patient tag.
+     * The tag name is validated to be a valid patient tag name, prefixed with "priority: ".
+     * If the tag name is not valid, a ParseException is thrown.
+     *
+     * @param tag The string to be parsed into a patient Tag object.
+     * @return A Tag object representing the patient tag.
+     * @throws ParseException if the tag name is not a valid patient tag name.
+     * @throws NullPointerException if the tag parameter is null.
+     */
+    public static Tag parsePatientTag(String tag) throws ParseException {
+        requireNonNull(tag);
+        String trimmedTag = tag.trim().toUpperCase();
+        if (!Tag.isValidPatientTagName(trimmedTag)) {
+            throw new ParseException(Tag.INVALID_PATIENT_TAG);
+        }
+        return new Tag("priority: " + trimmedTag);
+    }
+
+    /**
+     * Parses a collection of strings to create a set of {@code Tag} objects representing patient tags.
+     * If more than one tag is provided, a ParseException is thrown since patients should only have one tag.
+     * Each tag is validated to be a proper patient tag.
+     *
+     * @param tags The collection of strings to be parsed into patient Tag objects.
+     * @return A set of Tag objects representing the patient tags.
+     * @throws ParseException if the collection contains more than one tag or if the tag is not valid.
+     * @throws NullPointerException if the tags parameter is null.
+     */
+    public static Set<Tag> parsePatientTags(Collection<String> tags) throws ParseException {
+        requireNonNull(tags);
+        final Set<Tag> tagSet = new HashSet<>();
+        if (tags.size() > 1) {
+            throw new ParseException(Tag.EXTRA_PATIENT_TAG);
+        }
+        for (String tagName : tags) {
+            tagSet.add(parsePatientTag(tagName));
+        }
+        return tagSet;
+    }
+
+    /**
+     * Parses a string to create a {@code Tag} object representing a doctor tag.
+     * The tag name is validated to be a valid doctor tag name. If the tag name is not valid,
+     * a ParseException is thrown.
+     *
+     * @param tag The string to be parsed into a doctor Tag object.
+     * @return A Tag object representing the doctor tag.
+     * @throws ParseException if the tag name is not a valid doctor tag name.
+     * @throws NullPointerException if the tag parameter is null.
+     */
+    public static Tag parseDoctorTag(String tag) throws ParseException {
+        requireNonNull(tag);
+        String trimmedTag = tag.trim().toUpperCase();
+        if (!Tag.isValidDoctorTagName(trimmedTag)) {
+            throw new ParseException(Tag.INVALID_DOCTOR_TAG);
+        }
+        return new Tag(trimmedTag);
+    }
+
+    /**
+     * Parses a collection of strings to create a set of {@code Tag} objects representing doctor tags.
+     * Duplicate tags are not allowed, and if found, a ParseException is thrown.
+     * Each tag is validated to be a proper doctor tag.
+     *
+     * @param tags The collection of strings to be parsed into doctor Tag objects.
+     * @return A set of Tag objects representing the doctor tags.
+     * @throws ParseException if a duplicate tag is detected or if the tag is not valid.
+     * @throws NullPointerException if the tags parameter is null.
+     */
+    public static Set<Tag> parseDoctorTags(Collection<String> tags) throws ParseException {
+        requireNonNull(tags);
+        final Set<Tag> tagSet = new HashSet<>();
+        for (String tagName : tags) {
+            Tag toAdd = parseDoctorTag(tagName);
+            if (tagSet.contains(toAdd)) {
+                throw new ParseException(Tag.DUPLICATE_TAG);
+            }
+            tagSet.add(toAdd);
         }
         return tagSet;
     }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -1,16 +1,18 @@
 package seedu.address.model.tag;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Tag in the address book.
- * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
+ * Guarantees: immutable; name is valid as declared in {@link #isValidPatientTagName(String)}
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String DUPLICATE_TAG = "Doctors should not have duplicate tags!";
+    public static final String EXTRA_PATIENT_TAG = "Each Patient should only have one priority tag!";
+    public static final String INVALID_PATIENT_TAG = "Patient tag should be a valid priority level: Low, Medium or"
+            + " High.";
+    public static final String INVALID_DOCTOR_TAG = "Doctor tag should be a valid specialisation.";
 
     public final String tagName;
 
@@ -21,15 +23,52 @@ public class Tag {
      */
     public Tag(String tagName) {
         requireNonNull(tagName);
-        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
         this.tagName = tagName;
     }
 
     /**
-     * Returns true if a given string is a valid tag name.
+     * Returns true if a given string is a valid patient tag name.
      */
-    public static boolean isValidTagName(String test) {
-        return test.matches(VALIDATION_REGEX);
+    public static boolean isValidPatientTagName(String test) {
+        for (ValidPatientTags tag : ValidPatientTags.values()) {
+            if (tag.name().equals(test)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if a given string is a valid patient tag name.
+     */
+    public static boolean isValidFullPatientTagName(String test) {
+        for (ValidPatientTags tag : ValidPatientTags.values()) {
+            String fullTagName = "priority: " + tag;
+            if (fullTagName.equals(test)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if a given string is a valid doctor tag name.
+     */
+    public static boolean isValidDoctorTagName(String test) {
+        for (ValidDoctorTags tag : ValidDoctorTags.values()) {
+            if (tag.name().equals(test)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isValidPatientTag() {
+        return isValidFullPatientTagName(tagName);
+    }
+
+    public boolean isValidDoctorTag() {
+        return isValidDoctorTagName(tagName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/ValidDoctorTags.java
+++ b/src/main/java/seedu/address/model/tag/ValidDoctorTags.java
@@ -1,0 +1,9 @@
+package seedu.address.model.tag;
+
+/**
+ * Enumeration of valid doctor specializations for doctor tags.
+ * These specializations are used to categorize doctors by their field of expertise.
+ */
+public enum ValidDoctorTags {
+        CARDIOLOGIST, ORTHOPEDIC, PEDIATRICIAN, DERMATOLOGIST, NEUROLOGIST, GENERAL_PRACTITIONER, PSYCHIATRIST, SURGEON
+}

--- a/src/main/java/seedu/address/model/tag/ValidPatientTags.java
+++ b/src/main/java/seedu/address/model/tag/ValidPatientTags.java
@@ -1,0 +1,8 @@
+package seedu.address.model.tag;
+
+/**
+ * Enumeration of valid priority levels for patient tags.
+ */
+public enum ValidPatientTags {
+    LOW, MEDIUM, HIGH
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -43,22 +43,22 @@ public class SampleDataUtil {
                     new Email("alexyeoh@example.com"), new Address("Blk 30 Geylang Street 29, #06-40"),
                     EMPTY_REMARK, new Gender("M"), new Ic("S1111111Z"), new Condition("Unknown"),
                     new BloodType("O+"), getAppointmentSet(APPOINTMENT_1, APPOINTMENT_2),
-                    getTagSet("friends")),
+                    getTagSet("priority: LOW")),
             new Patient(new Name("Bernice Yu"), new Phone("99272758"), new Phone("87438807"),
                     new Email("berniceyu@example.com"), new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                     EMPTY_REMARK, new Gender("F"), new Ic("S1111112Z"), new Condition("Unknown"),
                     new BloodType("O+"), getAppointmentSet(APPOINTMENT_3),
-                    getTagSet("colleagues", "friends")),
+                    getTagSet("priority: LOW")),
             new Patient(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Phone("87438807"),
                     new Email("charlotte@example.com"), new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
                     EMPTY_REMARK, new Gender("F"), new Ic("S1111113Z"), new Condition("Unknown"),
                     new BloodType("O+"), EMPTY_APPOINTMENTS,
-                    getTagSet("neighbours")),
+                    getTagSet("priority: MEDIUM")),
             new Patient(new Name("David Li"), new Phone("91031282"), new Phone("87438807"),
                     new Email("lidavid@example.com"), new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                     EMPTY_REMARK, new Gender("M"), new Ic("S1111114Z"), new Condition("Unknown"),
                     new BloodType("O+"), EMPTY_APPOINTMENTS,
-                    getTagSet("family")),
+                    getTagSet("priority: MEDIUM")),
             new Patient(new Name("Irfan Ibrahim"), new Phone("92492021"), new Phone("87438807"),
                     new Email("irfan@example.com"), new Address("Blk 47 Tampines Street 20, #17-35"), EMPTY_REMARK,
                     new Gender("M"), new Ic("S1111115Z"), new Condition("Unknown"), new BloodType("O+"),
@@ -66,7 +66,7 @@ public class SampleDataUtil {
             new Patient(new Name("Roy Balakrishnan"), new Phone("92624417"), new Phone("87438807"),
                     new Email("royb@example.com"), new Address("Blk 45 Aljunied Street 85, #11-31"), EMPTY_REMARK,
                     new Gender("M"), new Ic("S1111116Z"), new Condition("Unknown"), new BloodType("O+"),
-                    EMPTY_APPOINTMENTS, getTagSet("colleagues"))
+                    EMPTY_APPOINTMENTS, getTagSet("priority: HIGH"))
         };
     }
 
@@ -74,11 +74,11 @@ public class SampleDataUtil {
         return new Doctor[] {
             new Doctor(new Name("Adam Lim"), new Phone("87438000"), new Email("adamlim@example.com"),
                     new Address("Blk 30 Geylang Street 29, #06-40"), EMPTY_REMARK, new Gender("M"),
-                    new Ic("S8811111Z"), getAppointmentSet(APPOINTMENT_1), getTagSet("GP")),
+                    new Ic("S8811111Z"), getAppointmentSet(APPOINTMENT_1), getTagSet("SURGEON")),
             new Doctor(new Name("Bernard Tan"), new Phone("99272000"), new Email("bernardtan@example.com"),
                     new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), EMPTY_REMARK, new Gender("M"),
                     new Ic("S8811112Z"), getAppointmentSet(APPOINTMENT_2, APPOINTMENT_3),
-                    getTagSet("ENTspecialist"))
+                    getTagSet("CARDIOLOGIST"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedDoctor.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedDoctor.java
@@ -63,7 +63,7 @@ public class JsonAdaptedDoctor extends JsonAdaptedPerson {
         final Ic modelIc = checkIc();
         final List<Tag> personTags = new ArrayList<>();
         for (JsonAdaptedTag tag : this.getTags()) {
-            personTags.add(tag.toModelType());
+            personTags.add(tag.toModelDoctorType());
         }
         final Set<Tag> modelTags = new HashSet<>(personTags);
         final List<Appointment> personAppointments = new ArrayList<>();

--- a/src/main/java/seedu/address/storage/JsonAdaptedPatient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPatient.java
@@ -76,7 +76,7 @@ public class JsonAdaptedPatient extends JsonAdaptedPerson {
         final Ic modelIc = checkIc();
         final List<Tag> personTags = new ArrayList<>();
         for (JsonAdaptedTag tag : this.getTags()) {
-            personTags.add(tag.toModelType());
+            personTags.add(tag.toModelPatientType());
         }
         final Set<Tag> modelTags = new HashSet<>(personTags);
         final Condition modelCondition = checkCondition();

--- a/src/main/java/seedu/address/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTag.java
@@ -38,9 +38,16 @@ class JsonAdaptedTag {
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
      */
-    public Tag toModelType() throws IllegalValueException {
-        if (!Tag.isValidTagName(tagName)) {
-            throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);
+    public Tag toModelPatientType() throws IllegalValueException {
+        if (!Tag.isValidFullPatientTagName(tagName)) {
+            throw new IllegalValueException(Tag.INVALID_PATIENT_TAG);
+        }
+        return new Tag(tagName);
+    }
+
+    public Tag toModelDoctorType() throws IllegalValueException {
+        if (!Tag.isValidDoctorTagName(tagName)) {
+            throw new IllegalValueException(Tag.INVALID_DOCTOR_TAG);
         }
         return new Tag(tagName);
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateDoctorAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateDoctorAddressBook.json
@@ -10,7 +10,7 @@
       "gender": "F",
       "ic": "S9831263J",
       "tags": [
-        "friends"
+        "SURGEON"
       ]
     },
     {

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePatientAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePatientAddressBook.json
@@ -9,7 +9,7 @@
       "gender": "F",
       "ic": "S1234567Z",
       "tags": [
-        "friends"
+        "priority: LOW"
       ],
       "condition": "Unknown",
       "bloodType": "O+",

--- a/src/test/data/JsonSerializableAddressBookTest/typicalDoctorsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalDoctorsAddressBook.json
@@ -25,7 +25,7 @@
         }
       ],
       "tags": [
-        "friends"
+        "NEUROLOGIST"
       ]
     },
     {
@@ -45,8 +45,8 @@
         }
       ],
       "tags": [
-        "owesMoney",
-        "friends"
+        "CARDIOLOGIST",
+        "SURGEON"
       ]
     },
     {

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPatientsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPatientsAddressBook.json
@@ -10,7 +10,7 @@
       "gender": "F",
       "ic": "T0131267K",
       "tags": [
-        "friends"
+        "priority: HIGH"
       ],
       "condition": "NA",
       "bloodType": "O+",
@@ -25,8 +25,7 @@
       "gender": "M",
       "ic": "T0131268K",
       "tags": [
-        "owesMoney",
-        "friends"
+        "priority: LOW"
       ],
       "condition": "Type 1 Diabetes",
       "bloodType": "O-",
@@ -54,7 +53,7 @@
       "gender": "M",
       "ic": "T0131260K",
       "tags": [
-        "friends"
+        "priority: MEDIUM"
       ],
       "condition": "Kidney Failure",
       "bloodType": "A+",

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -55,8 +55,11 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_CHERYL = "123 Main Street, Anytown, USA";
     public static final String VALID_ADDRESS_DEREK = "456 Elm Avenue, Somewhereville, Canada";
 
-    public static final String VALID_TAG_HUSBAND = "husband";
-    public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TAG_LOW = "priority: LOW";
+    public static final String VALID_TAG_MEDIUM = "priority: MEDIUM";
+    public static final String VALID_TAG_HIGH = "priority: HIGH";
+    public static final String VALID_TAG_CARDIOLOGIST = "CARDIOLOGIST";
+    public static final String VALID_TAG_SURGEON = "SURGEON";
     public static final String VALID_GENDER_MALE = "M";
     public static final String VALID_GENDER_FEMALE = "F";
     public static final String VALID_NRIC_AMY = "S8643226I";
@@ -104,13 +107,15 @@ public class CommandTestUtil {
     public static final String CONDITION_DESC_BOB = " " + PREFIX_CONDITION + VALID_CONDITION_BOB;
     public static final String BLOODTYPE_DESC_AMY = " " + PREFIX_BLOODTYPE + VALID_BLOODTYPE_AMY;
     public static final String BLOODTYPE_DESC_BOB = " " + PREFIX_BLOODTYPE + VALID_BLOODTYPE_BOB;
-    public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String TAG_DESC_LOW = " " + PREFIX_TAG + "Low";
+    public static final String TAG_DESC_MEDIUM = " " + PREFIX_TAG + "Medium";
+    public static final String TAG_DESC_HIGH = " " + PREFIX_TAG + "High";
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
-    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_PATIENT_TAG_DESC = " " + PREFIX_TAG + "highest"; // not a priority level
+    public static final String INVALID_DOCTOR_TAG_DESC = " " + PREFIX_TAG + "nurse"; // not a valid specialisation
     public static final String INVALID_BLOODTYPE_DESC = " " + PREFIX_BLOODTYPE + "Z+";
     public static final String INVALID_CONDITION_DESC = " " + PREFIX_CONDITION + " ";
     public static final String INVALID_EMERGENCY_CONTACT_DESC = " " + PREFIX_EMERGENCY_CONTACT + "+6A";
@@ -133,13 +138,13 @@ public class CommandTestUtil {
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withBloodType(VALID_BLOODTYPE_AMY).withCondition(VALID_CONDITION_AMY)
                 .withGender(VALID_GENDER_FEMALE).withIc(VALID_NRIC_AMY)
-                .withTags(VALID_TAG_FRIEND).withBloodType(VALID_BLOODTYPE_AMY)
+                .withTags(VALID_TAG_LOW).withBloodType(VALID_BLOODTYPE_AMY)
                 .build();
 
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withGender(VALID_GENDER_MALE).withIc(VALID_NRIC_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_MEDIUM).build();
 
         DESC_CHERYL = new EditPersonDescriptorBuilder().withName(VALID_NAME_CHERYL)
                 .withPhone(VALID_PHONE_CHERYL).withEmail(VALID_EMAIL_CHERYL).withAddress(VALID_ADDRESS_CHERYL)

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_LOW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -75,10 +75,10 @@ public class EditCommandTest {
 
         PatientBuilder patientInList = new PatientBuilder(lastPatient);
         Patient editedPatient = patientInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_LOW).build();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_LOW).build();
         Ic nricLastPerson = lastPatient.getIc();
         EditCommand editCommand = new EditCommand(nricLastPerson, descriptor);
 

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -9,7 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_MEDIUM;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +53,7 @@ public class EditPersonDescriptorTest {
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different tags -> returns false
-        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_MEDIUM).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddPatientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPatientCommandParserTest.java
@@ -19,8 +19,8 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_CONDITION_DES
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMERGENCY_CONTACT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PATIENT_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
@@ -29,8 +29,8 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_LOW;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_MEDIUM;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BLOODTYPE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_CONDITION_BOB;
@@ -40,8 +40,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_GENDER_MALE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BLOODTYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONDITION;
@@ -51,6 +49,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPatient.AMY;
@@ -67,7 +66,6 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Patient;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PatientBuilder;
 
 public class AddPatientCommandParserTest {
@@ -75,30 +73,20 @@ public class AddPatientCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Patient expectedPatient = new PatientBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        Patient expectedPatient = new PatientBuilder(BOB).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + ADDRESS_DESC_BOB + GENDER_DESC_MALE + NRIC_DESC_BOB + CONDITION_DESC_BOB
-                        + BLOODTYPE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_FRIEND,
+                        + BLOODTYPE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_MEDIUM,
                 new AddPatientCommand(expectedPatient));
-
-
-        // multiple tags - all accepted
-        Patient expectedPatientMultipleTags = new PatientBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
-        assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                        + GENDER_DESC_MALE + NRIC_DESC_BOB + CONDITION_DESC_BOB + BLOODTYPE_DESC_BOB
-                        + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                new AddPatientCommand(expectedPatientMultipleTags));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPatientString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + GENDER_DESC_MALE + NRIC_DESC_BOB + CONDITION_DESC_BOB + BLOODTYPE_DESC_BOB
-                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_FRIEND;
+                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_LOW;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPatientString,
@@ -128,13 +116,17 @@ public class AddPatientCommandParserTest {
         assertParseFailure(parser, EMERGENCY_CONTACT_DESC_AMY + validExpectedPatientString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMERGENCY_CONTACT));
 
+        //multiple tags
+        assertParseFailure(parser, TAG_DESC_MEDIUM + validExpectedPatientString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TAG));
+
         // multiple fields repeated
         assertParseFailure(parser,
                 validExpectedPatientString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
-                        + CONDITION_DESC_AMY + BLOODTYPE_DESC_AMY + EMERGENCY_CONTACT_DESC_AMY
+                        + TAG_DESC_LOW + CONDITION_DESC_AMY + BLOODTYPE_DESC_AMY + EMERGENCY_CONTACT_DESC_AMY
                         + validExpectedPatientString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_NRIC, PREFIX_GENDER,
-                        PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_CONDITION, PREFIX_BLOODTYPE,
+                        PREFIX_ADDRESS, PREFIX_TAG, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_CONDITION, PREFIX_BLOODTYPE,
                         PREFIX_CONDITION, PREFIX_EMERGENCY_CONTACT));
 
         // invalid value followed by valid value
@@ -167,6 +159,10 @@ public class AddPatientCommandParserTest {
         assertParseFailure(parser, INVALID_EMERGENCY_CONTACT_DESC + validExpectedPatientString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMERGENCY_CONTACT));
 
+        //invalid tag
+        assertParseFailure(parser, INVALID_PATIENT_TAG_DESC + validExpectedPatientString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TAG));
+
         // valid value followed by invalid value
 
         // invalid name
@@ -196,6 +192,10 @@ public class AddPatientCommandParserTest {
         // invalid emergencyContact
         assertParseFailure(parser, validExpectedPatientString + INVALID_EMERGENCY_CONTACT_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMERGENCY_CONTACT));
+
+        // invalid tag
+        assertParseFailure(parser, validExpectedPatientString + INVALID_PATIENT_TAG_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TAG));
     }
 
     @Test
@@ -272,43 +272,38 @@ public class AddPatientCommandParserTest {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + NRIC_DESC_BOB + GENDER_DESC_MALE + CONDITION_DESC_BOB + BLOODTYPE_DESC_BOB
-                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_LOW, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + NRIC_DESC_BOB + GENDER_DESC_MALE + CONDITION_DESC_BOB + BLOODTYPE_DESC_BOB
-                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_LOW, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
                 + NRIC_DESC_BOB + GENDER_DESC_MALE + CONDITION_DESC_BOB + BLOODTYPE_DESC_BOB
-                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_LOW, Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
                 + NRIC_DESC_BOB + GENDER_DESC_MALE + CONDITION_DESC_BOB + BLOODTYPE_DESC_BOB
-                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
-
-        // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + NRIC_DESC_BOB + GENDER_DESC_MALE + CONDITION_DESC_BOB + BLOODTYPE_DESC_BOB
-                + EMERGENCY_CONTACT_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_LOW, Address.MESSAGE_CONSTRAINTS);
 
         // invalid condition
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + NRIC_DESC_BOB + GENDER_DESC_MALE + INVALID_CONDITION_DESC + BLOODTYPE_DESC_BOB
-                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Condition.MESSAGE_CONSTRAINTS);
+                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_LOW, Condition.MESSAGE_CONSTRAINTS);
 
 
         // invalid bloodType
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + NRIC_DESC_BOB + GENDER_DESC_MALE + CONDITION_DESC_BOB + INVALID_BLOODTYPE_DESC
-                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, BloodType.MESSAGE_CONSTRAINTS);
+                + EMERGENCY_CONTACT_DESC_BOB + TAG_DESC_LOW, BloodType.MESSAGE_CONSTRAINTS);
 
         // invalid emergencyContact
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + NRIC_DESC_BOB + GENDER_DESC_MALE + CONDITION_DESC_BOB + BLOODTYPE_DESC_BOB
-                + INVALID_EMERGENCY_CONTACT_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + INVALID_EMERGENCY_CONTACT_DESC + TAG_DESC_LOW, Phone.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
@@ -318,7 +313,7 @@ public class AddPatientCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + ADDRESS_DESC_BOB + NRIC_DESC_BOB + GENDER_DESC_MALE + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                        + ADDRESS_DESC_BOB + NRIC_DESC_BOB + GENDER_DESC_MALE + TAG_DESC_LOW,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPatientCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -16,13 +16,12 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_GENDER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.REMARK_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_LOW;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_MEDIUM;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_BLOODTYPE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_CONDITION_AMY;
@@ -33,8 +32,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_LOW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_MEDIUM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -55,7 +54,6 @@ import seedu.address.model.person.Gender;
 import seedu.address.model.person.Ic;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 public class EditCommandParserTest {
@@ -97,22 +95,12 @@ public class EditCommandParserTest {
         assertParseFailure(parser, VALID_NRIC_AMY + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, VALID_NRIC_AMY + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, VALID_NRIC_AMY + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, VALID_NRIC_AMY + INVALID_BLOODTYPE_DESC, BloodType.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, VALID_NRIC_AMY + INVALID_CONDITION_DESC, Condition.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, VALID_NRIC_AMY + INVALID_GENDER_DESC, Gender.MESSAGE_CONSTRAINTS);
 
         // invalid phone followed by valid email
         assertParseFailure(parser, VALID_NRIC_AMY + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
-
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, VALID_NRIC_AMY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
-                Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, VALID_NRIC_AMY + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
-                Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, VALID_NRIC_AMY + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
-                Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, VALID_NRIC_AMY + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY
@@ -122,13 +110,13 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        String userInput = VALID_NRIC_AMY + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND + BLOODTYPE_DESC_AMY
+        String userInput = VALID_NRIC_AMY + PHONE_DESC_BOB + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_LOW + BLOODTYPE_DESC_AMY
                 + CONDITION_DESC_AMY + GENDER_DESC_FEMALE + REMARK_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withCondition(VALID_CONDITION_AMY)
+                .withTags(VALID_TAG_LOW).withCondition(VALID_CONDITION_AMY)
                 .withBloodType(VALID_BLOODTYPE_AMY).withGender(VALID_GENDER_FEMALE).withRemark(VALID_REMARK_AMY)
                 .build();
         EditCommand expectedCommand = new EditCommand(new Ic(VALID_NRIC_AMY), descriptor);
@@ -175,8 +163,8 @@ public class EditCommandParserTest {
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
-        userInput = VALID_NRIC_AMY + TAG_DESC_FRIEND;
-        descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        userInput = VALID_NRIC_AMY + TAG_DESC_MEDIUM;
+        descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_MEDIUM).build();
         expectedCommand = new EditCommand(new Ic(VALID_NRIC_AMY), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -222,8 +210,8 @@ public class EditCommandParserTest {
 
         // mulltiple valid fields repeated
         userInput = VALID_NRIC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+                + TAG_DESC_MEDIUM + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_MEDIUM
+                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_LOW;
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -25,14 +25,19 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
-    private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_PATIENT_TAG = "priority: HIGHEST";
+    private static final String INVALID_DOCTOR_TAG1 = "NURSE";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
-    private static final String VALID_TAG_1 = "friend";
-    private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_TAG1 = "FRIENDS";
+    private static final String VALID_TAG2 = "STUDENT";
+    private static final String VALID_PATIENT_TAG1 = "priority: LOW";
+    private static final String VALID_PATIENT_TAG2 = "priority: HIGH";
+    private static final String VALID_DOCTOR_TAG1 = "SURGEON";
+    private static final String VALID_DOCTOR_TAG2 = "CARDIOLOGIST";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -154,20 +159,25 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTag_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTag(INVALID_TAG));
+    public void parsePatientTag_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePatientTag(INVALID_PATIENT_TAG));
     }
 
     @Test
-    public void parseTag_validValueWithoutWhitespace_returnsTag() throws Exception {
-        Tag expectedTag = new Tag(VALID_TAG_1);
-        assertEquals(expectedTag, ParserUtil.parseTag(VALID_TAG_1));
+    public void parseDoctorTag_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDoctorTag(INVALID_DOCTOR_TAG1));
     }
 
     @Test
-    public void parseTag_validValueWithWhitespace_returnsTrimmedTag() throws Exception {
-        String tagWithWhitespace = WHITESPACE + VALID_TAG_1 + WHITESPACE;
-        Tag expectedTag = new Tag(VALID_TAG_1);
+    public void parseTag_validValueWithoutWhitespace_returnsTag() {
+        Tag expectedTag = new Tag(VALID_TAG1);
+        assertEquals(expectedTag, ParserUtil.parseTag(VALID_TAG1));
+    }
+
+    @Test
+    public void parseTag_validValueWithWhitespace_returnsTrimmedTag() {
+        String tagWithWhitespace = WHITESPACE + VALID_TAG1 + WHITESPACE;
+        Tag expectedTag = new Tag(VALID_TAG1);
         assertEquals(expectedTag, ParserUtil.parseTag(tagWithWhitespace));
     }
 
@@ -177,8 +187,15 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTags_collectionWithInvalidTags_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG)));
+    public void parsePatientTags_collectionWithMultipleTags_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePatientTags(Arrays.asList(VALID_PATIENT_TAG1,
+                VALID_PATIENT_TAG2)));
+    }
+
+    @Test
+    public void parseDoctorTags_collectionWithInvalidTags_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDoctorTags(Arrays.asList(VALID_DOCTOR_TAG1,
+                INVALID_DOCTOR_TAG1)));
     }
 
     @Test
@@ -188,8 +205,18 @@ public class ParserUtilTest {
 
     @Test
     public void parseTags_collectionWithValidTags_returnsTagSet() throws Exception {
-        Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
-        Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
+        Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(VALID_TAG1, VALID_TAG2));
+        Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG1),
+                new Tag(VALID_TAG2)));
+
+        assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseTags_collectionWithValidDoctorTags_returnsTagSet() throws Exception {
+        Set<Tag> actualTagSet = ParserUtil.parseDoctorTags(Arrays.asList(VALID_DOCTOR_TAG1, VALID_DOCTOR_TAG2));
+        Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_DOCTOR_TAG1),
+                new Tag(VALID_DOCTOR_TAG2)));
 
         assertEquals(expectedTagSet, actualTagSet);
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_LOW;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalPatient.ALICE;
@@ -49,7 +49,7 @@ public class AddressBookTest {
     @Test
     public void resetData_withDuplicatePatient_throwsDuplicatePersonException() {
         // Two persons with the same identity fields
-        Patient editedAlice = new PatientBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Patient editedAlice = new PatientBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_LOW)
                 .build();
         List<Person> newPatients = Arrays.asList(ALICE, editedAlice);
         AddressBookStub newData = new AddressBookStub(newPatients);
@@ -76,7 +76,7 @@ public class AddressBookTest {
     @Test
     public void hasPatient_patientWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addPatient(ALICE);
-        Patient editedAlice = new PatientBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Patient editedAlice = new PatientBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_LOW)
                 .build();
         assertTrue(addressBook.hasPatient(editedAlice));
     }

--- a/src/test/java/seedu/address/model/person/DoctorTest.java
+++ b/src/test/java/seedu/address/model/person/DoctorTest.java
@@ -13,7 +13,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_CHERYL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_CHERYL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SURGEON;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalDoctor.ALICE;
 import static seedu.address.testutil.TypicalDoctor.CHERYL;
@@ -86,7 +86,7 @@ public class DoctorTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false
-        editedAlice = new DoctorBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        editedAlice = new DoctorBuilder(ALICE).withTags(VALID_TAG_SURGEON).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 

--- a/src/test/java/seedu/address/model/person/PatientTest.java
+++ b/src/test/java/seedu/address/model/person/PatientTest.java
@@ -12,7 +12,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_GENDER_MALE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_MEDIUM;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPatient.ALICE;
 import static seedu.address.testutil.TypicalPatient.BOB;
@@ -39,7 +39,7 @@ public class PatientTest {
 
         // same ic, all other attributes different -> returns true
         Patient editedAlice = new PatientBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).withName(VALID_NAME_BOB)
+                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_MEDIUM).withName(VALID_NAME_BOB)
                 .withGender(VALID_GENDER_MALE).withCondition(VALID_CONDITION_BOB).withBloodType(VALID_BLOODTYPE_BOB)
                 .withEmergencyContact(VALID_EMERGENCY_CONTACT_BOB).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
@@ -84,7 +84,7 @@ public class PatientTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false
-        editedAlice = new PatientBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        editedAlice = new PatientBuilder(ALICE).withTags(VALID_TAG_MEDIUM).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different emergency contact -> return false

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,5 +1,9 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -12,15 +16,63 @@ public class TagTest {
     }
 
     @Test
-    public void constructor_invalidTagName_throwsIllegalArgumentException() {
-        String invalidTagName = "";
-        assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
+    void testIsValidPatientTagName() {
+        assertTrue(Tag.isValidPatientTagName("LOW"));
+        assertTrue(Tag.isValidPatientTagName("MEDIUM"));
+        assertTrue(Tag.isValidPatientTagName("HIGH"));
+        assertFalse(Tag.isValidPatientTagName("URGENT"));
     }
 
     @Test
-    public void isValidTagName() {
-        // null tag name
-        assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+    void testIsValidFullPatientTagName() {
+        assertTrue(Tag.isValidFullPatientTagName("priority: LOW"));
+        assertFalse(Tag.isValidFullPatientTagName("LOW"));
+        assertFalse(Tag.isValidFullPatientTagName("priority: URGENT"));
+    }
+
+    @Test
+    void testIsValidDoctorTagName() {
+        assertTrue(Tag.isValidDoctorTagName("CARDIOLOGIST"));
+        assertTrue(Tag.isValidDoctorTagName("SURGEON"));
+        assertFalse(Tag.isValidDoctorTagName("NURSE"));
+    }
+
+    @Test
+    void testIsValidPatientTag() {
+        Tag validTag = new Tag("priority: HIGH");
+        Tag invalidTag = new Tag("HIGH");
+        assertTrue(validTag.isValidPatientTag());
+        assertFalse(invalidTag.isValidPatientTag());
+    }
+
+    @Test
+    void testIsValidDoctorTag() {
+        Tag validTag = new Tag("CARDIOLOGIST");
+        Tag invalidTag = new Tag("NURSE");
+        assertTrue(validTag.isValidDoctorTag());
+        assertFalse(invalidTag.isValidDoctorTag());
+    }
+
+    @Test
+    void testEquals() {
+        Tag tag1 = new Tag("CARDIOLOGIST");
+        Tag tag2 = new Tag("CARDIOLOGIST");
+        Tag tag3 = new Tag("SURGEON");
+        assertEquals(tag1, tag2);
+        assertNotEquals(tag1, tag3);
+    }
+
+    @Test
+    void testHashCode() {
+        Tag tag1 = new Tag("CARDIOLOGIST");
+        Tag tag2 = new Tag("CARDIOLOGIST");
+        assertEquals(tag1.hashCode(), tag2.hashCode());
+    }
+
+    @Test
+    void testToString() {
+        Tag tag = new Tag("CARDIOLOGIST");
+        assertEquals("[CARDIOLOGIST]", tag.toString());
     }
 
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedDoctorTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedDoctorTest.java
@@ -26,7 +26,7 @@ public class JsonAdaptedDoctorTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_GENDER = "G";
     private static final String INVALID_NRIC = "T33340K";
-    private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_TAG = "nurse";
 
 
     private static final String VALID_NAME = BOYD.getName().toString();

--- a/src/test/java/seedu/address/testutil/TypicalDoctor.java
+++ b/src/test/java/seedu/address/testutil/TypicalDoctor.java
@@ -30,11 +30,11 @@ public class TypicalDoctor {
     public static final Doctor ALICE = new DoctorBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withRemark("She wants to become a Surgeon.").withGender("F").withIc("S9631267K")
-            .withTags("friends").withAppointments(APPOINTMENT_1, APPOINTMENT_2).build();
+            .withTags("NEUROLOGIST").withAppointments(APPOINTMENT_1, APPOINTMENT_2).build();
     public static final Doctor BOYD = new DoctorBuilder().withName("Boyd Anders")
             .withAddress("311, Clementi Ave 2, #02-25").withRemark("His weakness is being a Perfectionist")
             .withEmail("boyda@example.com").withPhone("98765432").withGender("M").withIc("S9331268K")
-            .withTags("owesMoney", "friends").withAppointments(APPOINTMENT_1).build();
+            .withTags("CARDIOLOGIST", "SURGEON").withAppointments(APPOINTMENT_1).build();
     public static final Doctor CARLOS = new DoctorBuilder().withName("Carlos Sainz").withPhone("95352563")
             .withEmail("smoothoperator@example.com").withAddress("wall street").withGender("M")
             .withIc("S9831269K").build();

--- a/src/test/java/seedu/address/testutil/TypicalPatient.java
+++ b/src/test/java/seedu/address/testutil/TypicalPatient.java
@@ -20,8 +20,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_MEDIUM;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,17 +37,18 @@ public class TypicalPatient {
     public static final Patient ALICE = new PatientBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withRemark("She likes aardvarks.").withGender("F").withIc("T0131267K")
-            .withTags("friends").withCondition("NA").withBloodType("O+").withEmergencyContact("90234567").build();
+            .withTags("priority: HIGH").withCondition("NA").withBloodType("O+")
+            .withEmergencyContact("90234567").build();
     public static final Patient BENSON = new PatientBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25").withRemark("He can't take beer!")
             .withEmail("johnd@example.com").withPhone("98765432").withGender("M").withIc("T0131268K")
-            .withTags("owesMoney", "friends").withCondition("Type 1 Diabetes").withBloodType("O-")
+            .withTags("priority: LOW").withCondition("Type 1 Diabetes").withBloodType("O-")
             .withEmergencyContact("92234567").build();
     public static final Patient CARL = new PatientBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withGender("M").withIc("T0131269K")
             .withCondition("Type 2 Diabetes").withBloodType("AB+").withEmergencyContact("91334567").build();
     public static final Patient DANIEL = new PatientBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends")
+            .withEmail("cornelia@example.com").withAddress("10th street").withTags("priority: MEDIUM")
             .withGender("M").withIc("T0131260K").withCondition("Kidney Failure").withBloodType("A+")
             .withEmergencyContact("91234567").build();
     public static final Patient ELLE = new PatientBuilder().withName("Elle Meyer").withPhone("9482224")
@@ -74,12 +74,12 @@ public class TypicalPatient {
             .withEmergencyContact(VALID_EMERGENCY_CONTACT_AMY).withEmail(VALID_EMAIL_AMY)
             .withAddress(VALID_ADDRESS_AMY).withIc(VALID_NRIC_AMY).withGender(VALID_GENDER_FEMALE)
             .withRemark(VALID_REMARK_AMY).withCondition(VALID_CONDITION_AMY).withBloodType(VALID_BLOODTYPE_AMY)
-            .withTags(VALID_TAG_FRIEND).build();
+            .withTags(VALID_TAG_MEDIUM).build();
     public static final Patient BOB = new PatientBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmergencyContact(VALID_EMERGENCY_CONTACT_BOB).withEmail(VALID_EMAIL_BOB)
             .withAddress(VALID_ADDRESS_BOB).withIc(VALID_NRIC_BOB).withGender(VALID_GENDER_MALE)
             .withRemark(VALID_REMARK_BOB).withCondition(VALID_CONDITION_BOB).withBloodType(VALID_BLOODTYPE_BOB)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+            .withTags(VALID_TAG_MEDIUM).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 


### PR DESCRIPTION
Previously, tags consisted of any alphanumeric strings. I have updated the addressbook to only accept priority levels for patient tags as well as specialisations for doctor tags. Patients can only have a single tag while doctors can have multiple specialisation tags.

Updated test cases to handle new tag format. Will add more test cases in the next commit to cover all new methods created and to double check for the presence of possible bugs.